### PR TITLE
Fixing variable name conflict

### DIFF
--- a/yt-telegram-bot.py
+++ b/yt-telegram-bot.py
@@ -10,10 +10,10 @@ Session = sessionmaker(bind=engine)
 session = Session()
 
 def vidindb():
-    vids = []
+    videos = []
     for vid in session.query(vids):
-        vids.append(vid.v_id)
-    return(vids)
+        videos.append(vid.v_id)
+    return(videos)
 
 def dbinsert(title, id, date):
     vid = vids(title, id, date)


### PR DESCRIPTION
`vids` is used both as a name of a variable in the code and as a name of a database object. The `session.query(vids)` call fails as Python is sending an empty list as an argument instead of the `vids` word as a database object name. 
This is my first encounter with Sqlalchemy and I have no much experience with Python, so maybe there is a smarter way to repair that, but renaming the `vids` Python variable worked for me.